### PR TITLE
Adds Installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 Patches a ROM file with a jump table and generates the necessary jump table
 index definitions.
 
+## Installation
+
+For Linux/Mac/etc, install cmake, make, asciidoc, and a C compiler,
+then:
+
+    $ cmake .
+    $ make
+	# make install # as root
+
+On Windows, do the same thing under cygwin after installing cmake,
+your favorite C compiler, and asciidoc.
+
 ## Help, Bugs, Feedback
 
 If you need help with KnightOS, want to keep up with progress, chat with


### PR DESCRIPTION
All of the other parts of the toolchain have an Installation
section with compilation instructions, but patchrom did not.
This commit copies the instructions from mkrom which appear to
be sufficient for compiling and installing patchrom on GNU/Linux.

Signed-off-by: zachwick zach@zachwick.com
